### PR TITLE
Remove edsa-nuget from .htaccess (non-standard)

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -9,80 +9,80 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/\$metadata  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=metadata   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/\$metadata  [NC] 
+RewriteRule  .* /api/v1/index.php?action=metadata   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Search\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=search&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Search\(\)/\$count  [NC] 
+RewriteRule  .* /api/v1/index.php?action=search&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Search\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=search   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
-RewriteRule (.*)api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /edsa-nuget/api/v1/index.php?action=single&id=$2&version=$3&%1 [NC,L]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=packages&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=packages&count=true   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=packages   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Search\(\)  [NC] 
+RewriteRule  .* /api/v1/index.php?action=search   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
+RewriteRule (.*)api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /api/v1/index.php?action=single&id=$2&version=$3&%1 [NC,L]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages\(\)/\$count  [NC] 
+RewriteRule  .* /api/v1/index.php?action=packages&count=true  [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages/\$count  [NC] 
+RewriteRule  .* /api/v1/index.php?action=packages&count=true   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages  [NC] 
+RewriteRule  .* /api/v1/index.php?action=packages   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById\(\)/\$count  [NC] 
+RewriteRule  .* /api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById  [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById\(\)  [NC] 
+RewriteRule  .* /api/v1/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById/\$count [NC] 
-RewriteRule  .* /edsa-nuget/api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById  [NC] 
+RewriteRule  .* /api/v1/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/package/([^/]+)/([^/]+)  [NC] 
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById/\$count [NC] 
+RewriteRule  .* /api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/package/([^/]+)/([^/]+)  [NC] 
 RewriteCond %{QUERY_STRING} ^(.*)$
-RewriteRule (.*)api/v1/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&version=$3&%1 [NC,L]
+RewriteRule (.*)api/v1/package/([^/]+)/([^/]+)$  /api/?id=$2&version=$3&%1 [NC,L]
 
 
 #API V2
@@ -91,123 +91,123 @@ RewriteRule (.*)api/v1/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&version=
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/\$metadata  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=metadata   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/\$metadata  [NC] 
+RewriteRule  .* /api/v2/index.php?action=metadata   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Search\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=search&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Search\(\)/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=search&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
-RewriteRule (.*)api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /edsa-nuget/api/v2/index.php?action=single&id=$2&version=$3&%1 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
+RewriteRule (.*)api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /api/v2/index.php?action=single&id=$2&version=$3&%1 [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Search\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=search   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Search\(\)  [NC] 
+RewriteRule  .* /api/v2/index.php?action=search   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=packages&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(\)/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=packages&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=packages&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=packages&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=packages   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages  [NC] 
+RewriteRule  .* /api/v2/index.php?action=packages   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=packages   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/GetUpdates\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=getupdates&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(\)  [NC] 
+RewriteRule  .* /api/v2/index.php?action=packages   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/GetUpdates\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=getupdates   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/GetUpdates\(\)/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=getupdates&count=true  [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById\(\)/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById/\$count  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/GetUpdates\(\)  [NC] 
+RewriteRule  .* /api/v2/index.php?action=getupdates   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById\(\)/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackageById\(\)  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById/\$count  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackageById  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById\(\)  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/package/([^/]+)/([^/]+)  [NC] 
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackageById\(\)  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackageById  [NC] 
+RewriteRule  .* /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/package/([^/]+)/([^/]+)  [NC] 
 RewriteCond %{QUERY_STRING} ^(.*)$
-RewriteRule (.*)api/v2/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&version=$3&%1 [NC,L]
+RewriteRule (.*)api/v2/package/([^/]+)/([^/]+)$  /api/?id=$2&version=$3&%1 [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_METHOD}  !GET
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/package  [NC] 
-RewriteRule .*  /edsa-nuget/upload/ [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v2/package  [NC] 
+RewriteRule .*  /upload/ [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/\$batch  [NC] 
-RewriteRule  .* /edsa-nuget/api/v2/batch.php   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/\$batch  [NC] 
+RewriteRule  .* /api/v2/batch.php   [QSA]
 
 #API V3
 
@@ -215,54 +215,54 @@ RewriteRule  .* /edsa-nuget/api/v2/batch.php   [QSA]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/index.json  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=resources   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/index.json  [NC] 
+RewriteRule  .* /api/v3/index.php?action=resources   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/fields  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=searchFields   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/fields  [NC] 
+RewriteRule  .* /api/v3/index.php?action=searchFields   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/query  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=searchQuery   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/diag  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=searchDiag   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/query  [NC] 
+RewriteRule  .* /api/v3/index.php?action=searchQuery   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=searchResources   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search  [NC] 
-RewriteRule  .* /edsa-nuget/api/v3/index.php?action=searchService   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/registration/([^/]+)/([^/]+).json  [NC] 
-RewriteRule (.*)api/v3/package/([^/]+)/([^/]+)$  /edsa-nuget/api/v3/index.php?action=package&id=$2&version=$3 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/diag  [NC] 
+RewriteRule  .* /api/v3/index.php?action=searchDiag   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/registration/([^/]+)/index.json  [NC] 
-RewriteRule (.*)api/v3/package/([^/]+)/([^/]+)$  /edsa-nuget/api/v3/index.php?action=packages&id=$2 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service  [NC] 
+RewriteRule  .* /api/v3/index.php?action=searchResources   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search  [NC] 
+RewriteRule  .* /api/v3/index.php?action=searchService   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/registration/([^/]+)/([^/]+).json  [NC] 
+RewriteRule (.*)api/v3/package/([^/]+)/([^/]+)$  /api/v3/index.php?action=package&id=$2&version=$3 [NC,L]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/registration/([^/]+)/index.json  [NC] 
+RewriteRule (.*)api/v3/package/([^/]+)/([^/]+)$  /api/v3/index.php?action=packages&id=$2 [NC,L]
 
 
 #Commons

--- a/src/ManagedFusion.Rewriter.txt
+++ b/src/ManagedFusion.Rewriter.txt
@@ -9,80 +9,80 @@ RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/\$metadata  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=metadata   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/\$metadata  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=metadata   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Search\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=search&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Search\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=search&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Search\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=search   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
-RewriteRule ^/(.*)api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /edsa-nuget/api/v1/index.php?action=single&id=$2&version=$3&%1 [NC,L]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=packages&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=packages&count=true   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/Packages  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=packages   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Search\(\)  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=search   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
+RewriteRule ^/(.*)api/v1/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /api/v1/index.php?action=single&id=$2&version=$3&%1 [NC,L]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=packages&count=true  [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages/\$count  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=packages&count=true   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/Packages  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=packages   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById\(\)  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/FindPackagesById/\$count [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById  [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v1/package/([^/]+)/([^/]+)  [NC] 
+RewriteCond %{REQUEST_URI}  ^/api/v1/FindPackagesById/\$count [NC] 
+RewriteRule ^/(.*) /api/v1/index.php?action=findpackagesbyd&count=true  [QSA]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v1/package/([^/]+)/([^/]+)  [NC] 
 RewriteCond %{QUERY_STRING} ^(.*)$
-RewriteRule ^/(.*)api/v1/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&version=$3&%1 [NC,L]
+RewriteRule ^/(.*)api/v1/package/([^/]+)/([^/]+)$  /api/?id=$2&version=$3&%1 [NC,L]
 
 
 #API V2
@@ -91,123 +91,123 @@ RewriteRule ^/(.*)api/v1/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&versio
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/\$metadata  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=metadata   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/\$metadata  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=metadata   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Search\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=search&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Search\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=search&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
-RewriteRule ^/(.*)api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /edsa-nuget/api/v2/index.php?action=single&id=$2&version=$3&%1 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)  [NC] 
+RewriteRule ^/(.*)api/v2/Packages\(Id='([^/]+)',Version='([^/]+)'\)$  /api/v2/index.php?action=single&id=$2&version=$3&%1 [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Search\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=search   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Search\(\)  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=search   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=packages&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=packages&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=packages&count=true   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=packages&count=true   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=packages   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=packages   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/Packages\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=packages   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/GetUpdates\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=getupdates&count=true  [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/Packages\(\)  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=packages   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/GetUpdates\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=getupdates   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/GetUpdates\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=getupdates&count=true  [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById\(\)/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById/\$count  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/GetUpdates\(\)  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=getupdates   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackagesById  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById\(\)/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackageById\(\)  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById/\$count  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd&count=true  [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/FindPackageById  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/index.php?action=findpackagesbyd   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById\(\)  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/package/([^/]+)/([^/]+)  [NC] 
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackagesById  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackageById\(\)  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/FindPackageById  [NC] 
+RewriteRule ^/(.*) /api/v2/index.php?action=findpackagesbyd   [QSA]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v2/package/([^/]+)/([^/]+)  [NC] 
 RewriteCond %{QUERY_STRING} ^(.*)$
-RewriteRule ^/(.*)api/v2/package/([^/]+)/([^/]+)$  /edsa-nuget/api/?id=$2&version=$3&%1 [NC,L]
+RewriteRule ^/(.*)api/v2/package/([^/]+)/([^/]+)$  /api/?id=$2&version=$3&%1 [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_METHOD}  !GET
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/package  [NC] 
-RewriteRule .*  /edsa-nuget/upload/ [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v2/package  [NC] 
+RewriteRule .*  /upload/ [NC,L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v2/\$batch  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v2/batch.php   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v2/\$batch  [NC] 
+RewriteRule ^/(.*) /api/v2/batch.php   [QSA]
 
 #API V3
 
@@ -215,54 +215,54 @@ RewriteRule ^/(.*) /edsa-nuget/api/v2/batch.php   [QSA]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/index.json  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=resources   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/index.json  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=resources   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/fields  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=searchFields   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/fields  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=searchFields   [QSA]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/query  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=searchQuery   [QSA]
-
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service/diag  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=searchDiag   [QSA]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/query  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=searchQuery   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search/service  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=searchResources   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/search  [NC] 
-RewriteRule ^/(.*) /edsa-nuget/api/v3/index.php?action=searchService   [QSA]
-
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/registration/([^/]+)/([^/]+).json  [NC] 
-RewriteRule ^/(.*)api/v3/package/([^/]+)/([^/]+)$  /edsa-nuget/api/v3/index.php?action=package&id=$2&version=$3 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service/diag  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=searchDiag   [QSA]
 
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_URI}  !index\.php          [NC]
-RewriteCond %{REQUEST_URI}  ^/edsa-nuget/api/v3/registration/([^/]+)/index.json  [NC] 
-RewriteRule ^/(.*)api/v3/package/([^/]+)/([^/]+)$  /edsa-nuget/api/v3/index.php?action=packages&id=$2 [NC,L]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search/service  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=searchResources   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/search  [NC] 
+RewriteRule ^/(.*) /api/v3/index.php?action=searchService   [QSA]
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/registration/([^/]+)/([^/]+).json  [NC] 
+RewriteRule ^/(.*)api/v3/package/([^/]+)/([^/]+)$  /api/v3/index.php?action=package&id=$2&version=$3 [NC,L]
+
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI}  !index\.php          [NC]
+RewriteCond %{REQUEST_URI}  ^/api/v3/registration/([^/]+)/index.json  [NC] 
+RewriteRule ^/(.*)api/v3/package/([^/]+)/([^/]+)$  /api/v3/index.php?action=packages&id=$2 [NC,L]
 
 
 #Commons


### PR DESCRIPTION
The edsa-nuget sub-directory in .htaccess is not standard. This causes issues when implementing in standard environments.