### PR TITLE
Fix header issues with logincontroller

### DIFF
--- a/src/_header.php
+++ b/src/_header.php
@@ -1,7 +1,4 @@
 <?php
-require_once(dirname(__FILE__)."/root.php");
-require_once(__ROOT__."/inc/logincontroller.php");
-
 $searchQuery = UrlUtils::GetRequestParamOrDefault("searchQuery","");
 
 ?>

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,8 @@
 <?php
 require_once(dirname(__FILE__)."/root.php");
 require_once(__ROOT__."/settings.php");
-require_once(__ROOT__."/inc/commons/url.php");
+require_once(__ROOT__."/inc/commons/url.php");	
+require_once(__ROOT__."/inc/logincontroller.php");
 
 if(UrlUtils::RequestMethod()=="put"){
 	require_once(__ROOT__."/upload/index.php");


### PR DESCRIPTION
The current header include implementation is causing session issues on php 5.6.30 on linux. It causes "Warning: Cannot modify header information - headers already sent by..." to occur, messing with the session, and causing UI interruptions (blank page if display errors is disabled, or showing the warnings).

![image](https://user-images.githubusercontent.com/14616851/51802984-3035ca80-2215-11e9-84ef-0021cabe607b.png)

You might think there is not a problem if display errors is false or error reporting is not set to display warnings, but if you try to log in, you will get a blank page.

