### PR TITLE
Added HTTP_X_FORWARDED_PROTO flag for determining SSL urls

### DIFF
--- a/src/inc/commons/url.php
+++ b/src/inc/commons/url.php
@@ -53,7 +53,8 @@ class UrlUtils
 		
 	public static function CurrentUrl($requestUri = "") {
         $pageURL = 'http';
-        if (array_key_exists("HTTPS",$_SERVER) && $_SERVER["HTTPS"] == "on") {
+        if ((array_key_exists("HTTPS",$_SERVER) && $_SERVER["HTTPS"] == "on") || 
+			(array_key_exists("HTTP_X_FORWARDED_PROTO", $_SERVER) && $_SERVER["HTTP_X_FORWARDED_PROTO"] = "https")) {
 			$pageURL .= "s";
 		}
 		


### PR DESCRIPTION
In docker environments running behind a reverse proxy, the HTTPS protocol is not correctly handled, because the container may be running in port 80, but the reverse proxy is sending requests through HTTPS.

Checking the ```HTTP_X_FORWARDED_PROTO``` header fixes issues with the proper protocol being used when setting up download URLs, etc.