### PR TITLE
Correct password saving issues, descriptive login error messages

### DIFF
--- a/src/inc/api_users.php
+++ b/src/inc/api_users.php
@@ -70,27 +70,26 @@ class UsersApi extends SmallTextDbApiBase
 	
 		$newPasswordConfirm = UrlUtils::GetRequestParam("NewPasswordConfirm");
 		$newPassword = UrlUtils::GetRequestParam("NewPassword");
+		$password = UrlUtils::GetRequestParam("Password");
 		
-		
-		$password =md5(UrlUtils::GetRequestParam("Password"));
-		
-		if($password!=$old->Md5Password && $isAdmin==false){
-			throw new Exception("Authentication failed");
-		}
-		
-		if(strlen($newPassword)>0){
-			if($newPassword!=$newPasswordConfirm){
-				throw new Exception("Passwords must match!");
+		if (strlen($password) == 0 && strlen($newPassword) == 0) {
+			$password = $old->Md5Password;
+		} else {
+			$password = md5($password);
+			
+			if($password!=$old->Md5Password && $isAdmin==false){
+				throw new Exception("Authentication failed");
 			}
-			if(strlen($newPassword)<8){
-				throw new Exception("Passwords must be at least 8 chars wide!");
-			}
-			$password = md5($newPassword);
-		}
-		
-		if($isAdmin==false){
-			$new->Admin = $old->Admin;
-			$new->Enabled = $old->Enabled;
+			
+			if(strlen($newPassword)>0){
+				if($newPassword!=$newPasswordConfirm){
+					throw new Exception("Passwords must match!");
+				}
+				if(strlen($newPassword)<8){
+					throw new Exception("Passwords must be at least 8 chars wide!");
+				}
+				$password = md5($newPassword);
+			}			
 		}
 		
 		if($isAdmin){

--- a/src/inc/partials/_logon.php
+++ b/src/inc/partials/_logon.php
@@ -66,6 +66,16 @@
 								<input type="submit" value="Sign In" class="btn btn-default"></input>
 							</div>
 						</div>
+						<?php if(isset($_GET["result"]) && strlen($_GET["result"]) > 0) {?>
+						<div class="form-group">
+							<div class="col-md-offset-2 col-md-10">
+								<div class="alert alert-danger alert-dismissible fade in">
+									<a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>								
+									<?php echo base64_decode($_GET["result"]); ?>
+								</div>
+							</div>
+						</div>
+						<?php } ?>
 					</form>
 				</div><!-- col ends -->
 				<?php


### PR DESCRIPTION
Introduces better login error messages, such as:
* User does not exist.
* Incorrect password.
* User is currently disabled.

Corrects an issue with saving users, where the password gets overwritten by a hash even when there was no new password entered.

Might need to apply PR #64 first in order to correct ```session_start()``` issues.

Examples:
![image](https://user-images.githubusercontent.com/14616851/51871126-26968a80-231b-11e9-997b-f9fb2e2ce367.png)
![image](https://user-images.githubusercontent.com/14616851/51871155-38782d80-231b-11e9-8503-ae613b4416e7.png)
![image](https://user-images.githubusercontent.com/14616851/51871510-234fce80-231c-11e9-83e4-e9bb1e8bf1e6.png)

There remains an issue with saving users where some of the data is not being properly saved. This is outlined on issue #68.

