### PR TITLE
Honour a web proxy setting when fetching external nuget packages

### DIFF
--- a/src/inc/api_packages.php
+++ b/src/inc/api_packages.php
@@ -25,6 +25,15 @@ class SingleResult
 }
 
 function getSslPage($url) {
+
+    if ( defined('__HTTPPROXY__') && (__HTTPPROXY__ !== '')) {
+      $proxy = __HTTPPROXY__;
+    } elseif (getenv('http_proxy')) {
+      $proxy = getenv('http_proxy');
+    } else {
+      $proxy = null;
+    }
+    
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
     curl_setopt($ch, CURLOPT_HEADER, false);
@@ -32,6 +41,7 @@ function getSslPage($url) {
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_REFERER, $url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+    curl_setopt($ch, CURLOPT_PROXY, $proxy);
     $result = curl_exec($ch);
     curl_close($ch);
     return $result;

--- a/src/settings.php
+++ b/src/settings.php
@@ -20,6 +20,13 @@ define('__ALLOWUSERADD__',false);
 define('__ALLOWPACKAGESDELETE__',true);
 define('__ALLOWPACKAGEUPDATE__', true);
 
+// Use a http proxy for fetching external nuget
+// packages. If this is not set, try to retrieve
+// the value of the http_proxy environment variable
+// and use that as the proxy. If both fails, don't
+// use a proxy.
+define('__HTTPPROXY__', '');
+
 @define('__MYSQL_SERVER__', "127.0.0.1");
 @define('__MYSQL_USER__',"root");
 @define('__MYSQL_PASSWORD__',"");


### PR DESCRIPTION
Phpnuget fails to fetch nuget packages from external servers (for importing them) if all network traffic must pass a central http[s] proxy. In this PR I propose the following:

Use a configured http proxy when fetching external nuget packages. If the configuration option is not set, try to retrieve the value of the http_proxy environment variable and use that as the proxy. If both fails, don't use a proxy.