### PR TITLE
Removed extra carriage returns

### DIFF
--- a/src/inc/db_usersentity.php
+++ b/src/inc/db_usersentity.php
@@ -33,4 +33,3 @@ if(defined('__ALLOWGRAVATAR__') && __ALLOWGRAVATAR__) {
     }
 }
 ?>
-


### PR DESCRIPTION
They were causing "Cannot modify header information" warnings.